### PR TITLE
Replace Farmware `uuid` with `name`

### DIFF
--- a/lib/farmbot/celery_script/commands/execute_script.ex
+++ b/lib/farmbot/celery_script/commands/execute_script.ex
@@ -6,34 +6,24 @@ defmodule Farmbot.CeleryScript.Command.ExecuteScript do
   alias   Farmbot.CeleryScript.{Command, Error, Types}
   alias   Farmbot.Farmware
   alias   Farmware.{Manager, Runtime}
-  import  Farmbot.Lib.Helpers
   require Logger
   @behaviour Command
 
   @doc ~s"""
     Executes a farmware
-      args: %{label: uuid or name},
+      args: %{label: name},
       body: [pair]
   """
   @spec run(%{label: binary}, Types.pairs, Context.t) :: Context.t | no_return
-  def run(%{label: uuid}, env_vars, context) when is_uuid(uuid) do
+  def run(%{label: name}, env_vars, context)  do
     new_context = Command.set_user_env(%{}, env_vars, context)
-    case Manager.lookup(context, uuid) do
+    case Manager.lookup_by_name(context, name) do
       {:ok, %Farmware{} = fw} ->
         Logger.debug ">> Starting Farmware: #{fw.name}", type: :busy
         Runtime.execute(new_context, fw)
       {:error, e}             ->
         raise Error, context: new_context,
           message: "Could not locate farmware: #{e}"
-    end
-  end
-
-  def run(%{label: not_uuid}, envs, context) when is_binary(not_uuid) do
-    case Manager.lookup_by_name(context, not_uuid) do
-      {:ok, fw}    -> run(%{label: fw.uuid}, envs, context)
-      {:error, _e} ->
-        raise Error, context: context,
-          message: "Could not locate farmware by name: #{not_uuid}"
     end
   end
 end

--- a/lib/farmbot/celery_script/commands/install_farmware.ex
+++ b/lib/farmbot/celery_script/commands/install_farmware.ex
@@ -13,7 +13,7 @@ defmodule Farmbot.CeleryScript.Command.InstallFarmware do
   """
   @spec run(%{url: binary}, [], Context.t) :: Context.t
   def run(%{url: url}, [], context) do
-    Farmbot.Farmware.Manager.install!(context, url)
+    Farmbot.Farmware.Installer.install!(context, url)
     context
   end
 end

--- a/lib/farmbot/celery_script/commands/take_photo.ex
+++ b/lib/farmbot/celery_script/commands/take_photo.ex
@@ -16,7 +16,7 @@ defmodule Farmbot.CeleryScript.Command.TakePhoto do
   @spec run(%{}, [], Context.t) :: Context.t
   def run(%{}, [], context) do
     case Farmware.Manager.lookup_by_name(context, "take-photo") do
-      {:ok, %Farmware{} = fw} -> execute_script(%{label: fw.uuid}, [], context)
+      {:ok, %Farmware{} = fw} -> execute_script(%{label: fw.name}, [], context)
       {:error, e}             -> raise Error, context: context,
         message: "Could not execute take photo: #{inspect e}"
     end

--- a/lib/farmbot/farmware.ex
+++ b/lib/farmbot/farmware.ex
@@ -37,7 +37,6 @@ defmodule Farmbot.Farmware do
 
   defstruct [
     :executable,
-    :uuid,
     :name,
     :meta,
     :args,
@@ -45,19 +44,18 @@ defmodule Farmbot.Farmware do
     :path
   ]
 
-  @typedoc false
-  @type uuid :: binary
-
   @typedoc """
     The url used to get updates, reinstall, etc.
   """
   @type url :: binary
 
+  @typedoc "Farmware name"
+  @type name :: binary
+
   @typedoc "Farmware Struct"
   @type t :: %__MODULE__{
     executable: binary,
-    uuid:       uuid,
-    name:       binary,
+    name:       name,
     url:        url,
     args:       [binary],
     meta:       Meta.t,
@@ -86,7 +84,6 @@ defmodule Farmbot.Farmware do
     }) do
     %__MODULE__{
       executable: exe,
-      uuid:       Nerves.Lib.UUID.generate(),
       args:       args,
       name:       name,
       url:        url,

--- a/lib/farmbot/farmware/manager.ex
+++ b/lib/farmbot/farmware/manager.ex
@@ -4,13 +4,9 @@ defmodule Farmbot.Farmware.Manager do
   """
   use Farmbot.Context.Worker
   alias Farmbot.Farmware
-  alias Farmware.Installer
 
   @typedoc false
   @type manager :: atom | pid
-
-  @typedoc false
-  @type uuid    :: binary
 
   @typedoc false
   @type url    :: binary
@@ -20,102 +16,28 @@ defmodule Farmbot.Farmware.Manager do
     defstruct [:context, :farmwares]
     @type t :: %{
       context: Context.t,
-      farmwares: %{optional(Farmbot.Farmware.Manager.uuid) => Farmware.t}
+      farmwares: %{optional(Farmware.name) => Farmware.t}
     }
   end
 
+  @typedoc false
   @type state :: State.t
 
-  @doc """
-    Looks up a `farmware` by its uuid or name.
-  """
-  @spec lookup(Context.t, uuid) :: {:ok, Farmware.t} | {:error, term}
-  def lookup(%Context{farmware_manager: fwt}, uuid) do
-    GenServer.call(fwt, {:lookup, uuid})
-  end
+  @typedoc "Farmware Name. Should be unique."
+  @type name :: Farmware.name
 
   @doc """
-    This exists for the sole purpose of `take-photo`.
+  Lookup a Farmware.
   """
-  @spec lookup_by_name(Context.t, binary) :: {:ok, Farmware.t} | {:error, term}
+  @spec lookup_by_name(Context.t, name) :: {:ok, Farmware.t} | {:error, term}
   def lookup_by_name(%Context{farmware_manager: fwt}, name) do
     GenServer.call(fwt, {:lookup_by_name, name})
   end
 
-  @doc """
-    Uninstall a farmware by its uuid.
-  """
-  @spec uninstall(Context, uuid) :: :ok | {:error, term}
-  def uninstall(%Context{farmware_manager: fwt} = ctx, uuid) do
-    case lookup(ctx, uuid) do
-      {:ok, %Farmware{} = fw} ->
-        Installer.uninstall!(ctx,  fw)
-        GenServer.call(fwt, {:unregister, uuid})
-      {:error, reason}        -> {:error, reason}
-    end
-  end
-
-  @doc """
-    Same as `uninstall/2` but raises if errors.
-  """
-  @spec uninstall!(Context.t, uuid) :: :ok | no_return
-  def uninstall!(%Context{} = ctx, uuid) do
-    case uninstall(ctx, uuid) do
-      {:ok, %Farmware{} = fw} -> fw
-      {:error, e}        -> raise RuntimeError, e
-    end
-  end
-
-  @doc """
-    Install a farmware from the internets.
-  """
-  @spec install(Context.t, url) :: :ok | {:error, term}
-  def install(%Context{farmware_manager: fwt} = ctx, url) do
-    try do
-      %Farmware{} = fw = Installer.install!(ctx, url)
-      debug_log "Begin register for #{inspect fw}"
-      GenServer.call(fwt, {:register, fw.uuid, fw})
-    rescue
-      e ->
-        debug_log "Rescued from error: #{inspect e}"
-        {:error, e}
-    end
-  end
-
-  @doc """
-    Same as `install/2` but raise if any errors.
-  """
-  def install!(%Context{} = ctx, url) do
-    case install(ctx, url) do
-      :ok -> :ok
-      {:error, e} -> reraise e, System.stacktrace()
-    end
-  end
-
-  @doc """
-    Updates a Farmware.
-  """
-  def update(%Context{} = ctx, uuid) do
-    try do
-      do_update(ctx, uuid)
-    rescue
-      e -> {:error, e}
-    end
-  end
-
-  @doc """
-    Same as `update/2` but raises if any errors.
-  """
-  def update!(%Context{} = ctx, uuid), do: do_update(ctx, uuid)
-
-  defp do_update(%Context{} = ctx, uuid) do
-    case lookup(ctx, uuid) do
-      {:ok, %Farmware{url: old_url}} ->
-        uninstall!(ctx, uuid)
-        install!(ctx, old_url)
-      {:error, reason} -> raise RuntimeError, "Could not update: #{inspect reason}"
-    end
-
+  @doc "ReIndex the manager."
+  @spec reindex(Context.t) :: state
+  def reindex(%Context{farmware_manager: fwt}) do
+    GenServer.call(fwt, :reindex)
   end
 
   ## GenServer stuff
@@ -128,7 +50,7 @@ defmodule Farmbot.Farmware.Manager do
     installed = root_path |> File.ls!
     fws = Map.new(installed, fn(name) ->
       fw = "#{root_path}/#{name}/manifest.json" |> File.read!() |> Poison.decode! |> Farmware.new
-      {fw.uuid, fw}
+      {fw.name, fw}
     end)
 
     state = %State{
@@ -140,15 +62,10 @@ defmodule Farmbot.Farmware.Manager do
     {:ok, state}
   end
 
-  def handle_call({:lookup, uuid}, _, state) do
-    reply     = fetch_fw(state, uuid)
-    dispatch reply, state
-  end
-
   def handle_call({:lookup_by_name, name}, _, state) do
     farmwares = state.farmwares
     reply = Enum.find_value(farmwares, {:error, :not_found},
-      fn({_uuid, %Farmware{name: fw_name} = fw}) ->
+      fn({fw_name, %Farmware{} = fw}) ->
         if fw_name == name do
           {:ok, fw}
         end
@@ -156,36 +73,14 @@ defmodule Farmbot.Farmware.Manager do
     dispatch reply, state
   end
 
-  def handle_call({:register, uuid, %Farmware{} = fw}, _, state) do
-    new_fws =
-      case Enum.find(state.farmwares, fn({_existing_uuid, existing_fw}) ->
-        existing_fw.name == fw.name
-      end) do
-        {existing_uuid, _old_fw} -> Map.put(state.farmwares, existing_uuid, fw)
-        _                        -> Map.put(state.farmwares, uuid,          fw)
-      end
-    reply   = :ok
-    debug_log "Registered Farmware: #{inspect fw}"
-    dispatch reply, %{ state | farmwares: new_fws}
-  end
-
-  def handle_call({:unregister, uuid}, _, state) do
-    reply   = fetch_fw(state, uuid)
-    new_fws = Map.delete(state.farmwares, uuid)
-    dispatch reply, %{state | farmwares: new_fws}
+  def handle_call(:reindex, _, state) do
+    {:ok, new} = init(state.context)
+    dispatch :ok, new
   end
 
   @spec dispatch(term, state) :: {:reply, term, state}
   defp dispatch(reply, state) do
     GenServer.cast(Farmbot.BotState.Monitor, state)
     {:reply, reply, state}
-  end
-
-  @spec fetch_fw(state, uuid) :: {:ok, Farmware.t} | {:error, :not_found}
-  defp fetch_fw(state, uuid) do
-    case state.farmwares[uuid] do
-      nil              -> {:error, :not_found}
-      %Farmware{} = fw -> {:ok, fw}
-    end
   end
 end


### PR DESCRIPTION
Reboots and other things were causing Farmware management to now quite work as intended. 

## Problem
* Reboots caused stale uuids in the FE
* Reboots caused accidental duplication of Farmwares
* It was possible for the `manager` to get out of sync  with the FE or with the Fillesystem.

## Solution
* Dumb down the manager. 
   * There is no UUID tracking anymore. It only tracks what is on the filesystem. If something changes, just call `Farmbot.Farmware.Manager.reindex()` and everything will _just work_ :tm: 
* No UUID, no stale UUID.